### PR TITLE
fixed an issue with attachment filenames having parenthesis and comma…

### DIFF
--- a/lib/libmime.js
+++ b/lib/libmime.js
@@ -339,13 +339,13 @@ var libmime = module.exports = {
             var value = structured.params[param];
             if (!libmime.isPlainText(value) || value.length >= 75) {
                 libmime.buildHeaderParam(param, value, 50).forEach(function (encodedParam) {
-                    if (!/[\s"\\;\/=]|^[\-']|'$/.test(encodedParam.value) || encodedParam.key.substr(-1) === '*') {
+                    if (!/[\s"\\;\/=\(\),]|^[\-']|'$/.test(encodedParam.value) || encodedParam.key.substr(-1) === '*') {
                         paramsArray.push(encodedParam.key + '=' + encodedParam.value);
                     } else {
                         paramsArray.push(encodedParam.key + '=' + JSON.stringify(encodedParam.value));
                     }
                 });
-            } else if (/[\s'"\\;\/=]|^\-/.test(value)) {
+            } else if (/[\s'"\\;\/=\(\),]|^\-/.test(value)) {
                 paramsArray.push(param + '=' + JSON.stringify(value));
             } else {
                 paramsArray.push(param + '=' + value);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libmime",
   "description": "Encode and decode quoted printable and base64 strings",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "lib/libmime",
   "homepage": "https://github.com/andris9/libmime",
   "repository": {

--- a/test/libmime-test.js
+++ b/test/libmime-test.js
@@ -346,6 +346,24 @@ describe('libmime', function () {
                 }
             })).to.equal('test; filename="document a.pdf"');
         });
+
+        it('should quote filename with special characters like parenthesis and comma', function () {
+            // The case of browser downloads when we download multiple files with same name.
+            expect(libmime.buildHeaderValue({
+                value: 'test',
+                params: {
+                    filename: 'receipt(3).pdf'
+                }
+            })).to.equal('test; filename="receipt(3).pdf"');
+
+            // For headers which are comma separated as in case of multiple from members elements.
+            expect(libmime.buildHeaderValue({
+                value: 'test',
+                params: {
+                    filename: 'jack,jill.pdf'
+                }
+            })).to.equal('test; filename="jack,jill.pdf"');
+        });
     });
 
     describe('#encodeFlowed', function () {


### PR DESCRIPTION
…. nodemailer/libmime#5


Background issue: #5 

I have also added support for the comma in a filename. Even that is creating problems with IMAP envelope commands.

Thanks,
Suraj