### PR TITLE
Fix issues with fixed lines and flowed content

### DIFF
--- a/lib/libmime.js
+++ b/lib/libmime.js
@@ -59,16 +59,16 @@ class Libmime {
                 // remove soft linebreaks
                 // soft linebreaks are added after space symbols
                 .reduce((previousValue, currentValue, index) => {
-                    let body = previousValue;
-                    if (delSp) {
-                        // delsp adds spaces to text to be able to fold it
-                        // these spaces can be removed once the text is unfolded
-                        body = body.replace(/[ ]+$/, '');
-                    }
-                    if ((/ $/.test(previousValue) && !/(^|\n)-- $/.test(previousValue)) || index === 1) {
-                        return body + currentValue;
+                    if ((/ $/.test(previousValue) && !/(^|\n)-- $/.test(previousValue))) {
+                        if (delSp) {
+                            // delsp adds space to text to be able to fold it
+                            // these spaces can be removed once the text is unfolded
+                            return previousValue.slice(0, -1) + currentValue
+                        } else {
+                            return previousValue + currentValue;
+                        }
                     } else {
-                        return body + '\n' + currentValue;
+                        return previousValue + '\n' + currentValue;
                     }
                 })
                 // remove whitespace stuffing

--- a/test/libmime-test.js
+++ b/test/libmime-test.js
@@ -522,6 +522,26 @@ describe('libmime', () => {
                     'abc';
             expect(libmime.decodeFlowed(folded, true)).to.equal(str);
         });
+
+        it('should remove SP CRLF before space', () => {
+            let str = 'first\nsecond\nthird continued',
+                folded =
+                    'first\r\n' +
+                    'second\r\n' +
+                    'third \r\n' +
+                    ' continued';
+            expect(libmime.decodeFlowed(folded, true)).to.equal(str);
+        });
+
+        it('should remove SP CRLF after space', () => {
+            let str = 'first\nsecond\nthird continued',
+                folded =
+                    'first\r\n' +
+                    'second\r\n' +
+                    'third  \r\n' +
+                    'continued';
+            expect(libmime.decodeFlowed(folded, true)).to.equal(str);
+        });
     });
 
     describe('#charset', () => {

--- a/test/libmime-test.js
+++ b/test/libmime-test.js
@@ -130,11 +130,11 @@ describe('libmime', () => {
             );
         });
 
-        it.only('should fail using iconv-lite module', () => {
+        it('should fail using iconv-lite module', () => {
             expect(libmime.decodeWords('=?ISO-2022-JP?B?GyRCM1g5OzU7PVEwdzgmPSQ4IUYkMnFKczlwGyhC?=')).to.not.equal('学校技術員研修検討会報告');
         });
 
-        it.only('should decode using iconv module', () => {
+        it('should decode using iconv module', () => {
             let lm = new libmime.Libmime({ Iconv });
             expect(lm.decodeWords('=?ISO-2022-JP?B?GyRCM1g5OzU7PVEwdzgmPSQ4IUYkMnFKczlwGyhC?=')).to.equal('学校技術員研修検討会報告');
         });


### PR DESCRIPTION
The following case is decoded wrong (delsp = true)

Input: `first\r\nsecond`
Output: `firstsecond`
Expected: `first\r\nsecond`