### PR TITLE
Join base64 encoding which ending with =, and decode correctly.

### DIFF
--- a/lib/libmime.js
+++ b/lib/libmime.js
@@ -223,7 +223,12 @@ class Libmime {
             }
             str = Buffer.from(bytes);
         } else if (encoding === 'B') {
-            str = Buffer.from(str, 'base64');
+            str = Buffer.concat(
+                str
+                    .split('=')
+                    .filter(s => s !== '') // filter empty string
+                    .map(str => Buffer.from(str, 'base64'))
+            );
         } else {
             // keep as is, convert Buffer to unicode string, assume utf8
             str = Buffer.from(str);
@@ -289,7 +294,7 @@ class Libmime {
             (str || '')
                 .toString()
                 // find base64 words that can be joined
-                .replace(/(=\?([^?]+)\?[Bb]\?[^?]+[^^=]\?=)\s*(?==\?([^?]+)\?[Bb]\?[^?]+\?=)/g, (match, left, chLeft, chRight) => {
+                .replace(/(=\?([^?]+)\?[Bb]\?[^?]+\?=)\s*(?==\?([^?]+)\?[Bb]\?[^?]+\?=)/g, (match, left, chLeft, chRight) => {
                     // only mark b64 chunks to be joined if charsets match
                     if (libcharset.normalizeCharset(chLeft || '') === libcharset.normalizeCharset(chRight || '')) {
                         // set a joiner marker

--- a/test/libmime-test.js
+++ b/test/libmime-test.js
@@ -98,6 +98,11 @@ describe('libmime', () => {
             );
         });
 
+        it('should join base64 encoding which end with = and decode correctly', () => {
+            const input = '=?UTF-8?B?MjAxOSDovrLmm4bmlrDlubTpm7vlrZDos4DljaHlj4rnsL3lkI3mqg==?= =?UTF-8?B?lA==?=';
+            expect(libmime.decodeWords(input)).to.equal('2019 農曆新年電子賀卡及簽名檔');
+        });
+
         it('should split QP on maxLength', () => {
             let inputStr = 'Jõgeva Jõgeva Jõgeva mugeva Jõgeva Jõgeva Jõgeva Jõgeva Jõgeva',
                 outputStr =


### PR DESCRIPTION
In some case, a wide character will be split to two base64 encoding  ending with `=`.
At current version, it will decode individually.
![output](https://imgur.com/skyiNgX.jpg)

