### PR TITLE
decodeWords should also decode empty content part

### DIFF
--- a/lib/libmime.js
+++ b/lib/libmime.js
@@ -294,7 +294,7 @@ class Libmime {
             (str || '')
                 .toString()
                 // find base64 words that can be joined
-                .replace(/(=\?([^?]+)\?[Bb]\?[^?]+\?=)\s*(?==\?([^?]+)\?[Bb]\?[^?]+\?=)/g, (match, left, chLeft, chRight) => {
+                .replace(/(=\?([^?]+)\?[Bb]\?[^?]*\?=)\s*(?==\?([^?]+)\?[Bb]\?[^?]*\?=)/g, (match, left, chLeft, chRight) => {
                     // only mark b64 chunks to be joined if charsets match
                     if (libcharset.normalizeCharset(chLeft || '') === libcharset.normalizeCharset(chRight || '')) {
                         // set a joiner marker
@@ -303,7 +303,7 @@ class Libmime {
                     return match;
                 })
                 // find QP words that can be joined
-                .replace(/(=\?([^?]+)\?[Qq]\?[^?]+\?=)\s*(?==\?([^?]+)\?[Qq]\?[^?]+\?=)/g, (match, left, chLeft, chRight) => {
+                .replace(/(=\?([^?]+)\?[Qq]\?[^?]*\?=)\s*(?==\?([^?]+)\?[Qq]\?[^?]*\?=)/g, (match, left, chLeft, chRight) => {
                     // only mark QP chunks to be joined if charsets match
                     if (libcharset.normalizeCharset(chLeft || '') === libcharset.normalizeCharset(chRight || '')) {
                         // set a joiner marker
@@ -314,9 +314,9 @@ class Libmime {
                 // join base64 encoded words
                 .replace(/(\?=)?__\x00JOIN\x00__(=\?([^?]+)\?[QqBb]\?)?/g, '')
                 // remove spaces between mime encoded words
-                .replace(/(=\?[^?]+\?[QqBb]\?[^?]+\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]+\?=)/g, '$1')
+                .replace(/(=\?[^?]+\?[QqBb]\?[^?]*\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]*\?=)/g, '$1')
                 // decode words
-                .replace(/=\?([\w_\-*]+)\?([QqBb])\?([^?]+)\?=/g, (m, charset, encoding, text) => this.decodeWord(charset, encoding, text))
+                .replace(/=\?([\w_\-*]+)\?([QqBb])\?([^?]*)\?=/g, (m, charset, encoding, text) => this.decodeWord(charset, encoding, text))
         );
     }
 

--- a/test/libmime-test.js
+++ b/test/libmime-test.js
@@ -143,6 +143,10 @@ describe('libmime', () => {
             let lm = new libmime.Libmime({ Iconv });
             expect(lm.decodeWords('=?ISO-2022-JP?B?GyRCM1g5OzU7PVEwdzgmPSQ4IUYkMnFKczlwGyhC?=')).to.equal('学校技術員研修検討会報告');
         });
+
+        it('should also decode content empty part', () => {
+            expect(libmime.decodeWords('=?UTF-8?Q??= =?UTF-8?Q?=E4=BD=A0=E5=A5=BD?=')).to.equal('你好');
+        });
     });
 
     describe('#buildHeaderParam', () => {


### PR DESCRIPTION
In some situation, mime encoding will contain empty part.
```
encoded:
=?UTF-8?Q??= =?UTF-8?Q?=E4=BD=A0=E5=A5=BD?=

wrong:
=?UTF-8?? 你好

correct:
你好
```
Please also update to latest version `libmime` in [mailparser](https://github.com/nodemailer/mailparser) for solving parsing mail problem.

Thanks.