### PR TITLE
Update iconv-lite from 0.6.2 to 0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "libmime",
     "description": "Encode and decode quoted printable and base64 strings",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "main": "lib/libmime",
     "homepage": "https://github.com/andris9/libmime",
     "repository": {
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "encoding-japanese": "1.0.30",
-        "iconv-lite": "0.6.2",
+        "iconv-lite": "0.6.3",
         "libbase64": "1.2.1",
         "libqp": "1.1.0"
     },


### PR DESCRIPTION
Bump iconv-lite from 0.6.2 to 0.6.3. This way, latest mailparser can use a single version