### PR TITLE
chore: bump libqp to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "encoding-japanese": "2.0.0",
         "iconv-lite": "0.6.3",
         "libbase64": "1.2.1",
-        "libqp": "1.1.0"
+        "libqp": "2.0.1"
     },
     "devDependencies": {
         "chai": "4.3.6",


### PR DESCRIPTION
# Why
package libqp 1.1.0 contains deprecated codes
```
[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```
# Changelog
- Bump package libqp to latest version 2.0.1

Plz help me this PR @andris9 