### PR TITLE
replace .npmignore with files=[] in package.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ jobs:
     test:
         strategy:
             matrix:
-                node: [16.x, 18.x, 20.x, 21.x]
+                node: [16, 18, 20, 21]
                 os: [ubuntu-latest]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node }}
               uses: actions/setup-node@v4
               with:

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-.travis.yml
-.jshintrc
-Gruntfile.js
-test

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "description": "Encode and decode quoted printable and base64 strings",
     "version": "5.3.5",
     "main": "lib/libmime.js",
+    "files": ["lib", "CHANGELOG.md"],
     "homepage": "https://github.com/nodemailer/libmime",
     "repository": {
         "type": "git",


### PR DESCRIPTION
net changes:

- no longer publishing all the dotfiles [on NPM](https://www.npmjs.com/package/libmime?activeTab=code)
- no more need to maintain .npmignore