### PR TITLE
Fix performance issue on large inputs to decodeFlowed()

### DIFF
--- a/lib/libmime.js
+++ b/lib/libmime.js
@@ -54,28 +54,42 @@ class Libmime {
     decodeFlowed(str, delSp) {
         str = (str || '').toString();
 
-        return (
-            str
-                .split(/\r?\n/)
-                // remove soft linebreaks
-                // soft linebreaks are added after space symbols
-                .reduce((previousValue, currentValue) => {
-                    if (/ $/.test(previousValue) && !/(^|\n)-- $/.test(previousValue)) {
-                        if (delSp) {
-                            // delsp adds space to text to be able to fold it
-                            // these spaces can be removed once the text is unfolded
-                            return previousValue.slice(0, -1) + currentValue;
-                        } else {
-                            return previousValue + currentValue;
-                        }
-                    } else {
-                        return previousValue + '\n' + currentValue;
-                    }
-                })
-                // remove whitespace stuffing
-                // http://tools.ietf.org/html/rfc3676#section-4.4
-                .replace(/^ /gm, '')
-        );
+        let lines = str.split(/\r?\n/);
+
+        let result = [],
+            buffer = null;
+
+        // remove soft linebreaks
+        // soft linebreaks are added after space symbols
+        for (let i = 0; i < lines.length; i++) {
+            let line = lines[i];
+
+            let isSoftBreak = buffer !== null && / $/.test(buffer) && !/(^|\n)-- $/.test(buffer);
+
+            if (isSoftBreak) {
+                if (delSp) {
+                    // delsp adds space to text to be able to fold it
+                    // these spaces can be removed once the text is unfolded
+                    buffer = buffer.slice(0, -1) + line;
+                } else {
+                    buffer += line;
+                }
+            } else {
+                if (buffer !== null) {
+                    result.push(buffer);
+                }
+
+                buffer = line;
+            }
+        }
+
+        if (buffer) {
+            result.push(buffer);
+        }
+
+        // remove whitespace stuffing
+        // http://tools.ietf.org/html/rfc3676#section-4.4
+        return result.join('\n').replace(/^ /gm, '');
     }
 
     /**


### PR DESCRIPTION
Fix for issue reported here: https://github.com/nodemailer/mailparser/issues/389

On my test EML, it produces the same exact same output, in only `11ms` vs `9098ms` with the previous `decodeFlowed()`.

Once this PR is accepted, the following dependency chain will need to be updated to the fixed `libmime` version:

```
- mailparser
  |- mailsplit
    |- libmime
```

Tests are all passing on my end following this patch.